### PR TITLE
Fix `parseclj-lex-character` for `\u` and `\o`

### DIFF
--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -297,11 +297,11 @@ token is returned."
       (right-char 7)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 
-     ((equal (char-after (point)) ?u)
+     ((string-match-p "^u[0-9a-fA-F]\\{4\\}" (parseclj-lex-lookahead 5))
       (right-char 5)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 
-     ((equal (char-after (point)) ?o)
+     ((string-match-p "^o[0-8]\\{3\\}" (parseclj-lex-lookahead 4))
       (right-char 4)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -114,6 +114,15 @@
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
 
   (with-temp-buffer
+    (insert "\\u \\v \\w")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u" 1)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :whitespace " " 3)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\v" 4)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :whitespace " " 6)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\w" 7))))
+
+  (with-temp-buffer
     (insert "\\u0078\\o170")
     (goto-char 1)
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u0078" 1)))

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -114,17 +114,6 @@
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
 
   (with-temp-buffer
-    (insert "\\newline\\return\\space\\tab\\a\\b\\c")
-    (goto-char 1)
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\newline" 1)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\return" 9)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\space" 16)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\tab" 22)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\a" 26)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\b" 28)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
-
-  (with-temp-buffer
     (insert "\\u0078\\o170")
     (goto-char 1)
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u0078" 1)))


### PR DESCRIPTION
Current behavior when reading a string like: `"\u \v \w"` is to produce only two character tokens:

```
((:node-type . :character) (:position . 1) (:form . "\\u \\v ") (:value . 0))
((:node-type . :character) (:position . 6) (:form . "\\w") (:value . 119))
```

Included a test that ensures proper token generation.