### PR TITLE
Loop reduction over the first 2 elements of the stack

### DIFF
--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -297,11 +297,11 @@ token is returned."
       (right-char 7)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 
-     ((equal (char-after (point)) ?u)
+     ((string-match-p "^u[0-9a-fA-F]\\{4\\}" (parseclj-lex-lookahead 5))
       (right-char 5)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 
-     ((equal (char-after (point)) ?o)
+     ((string-match-p "^o[0-8]\\{3\\}" (parseclj-lex-lookahead 4))
       (right-char 4)
       (parseclj-lex-token :character (buffer-substring-no-properties pos (point)) pos))
 

--- a/parseclj-parser.el
+++ b/parseclj-parser.el
@@ -203,15 +203,21 @@ functions. Additionally the following options are recognized
        (t (push token stack)))
 
       ;; Reduce based on top two items on the stack (special prefixed elements)
-      (let* ((top-value (parseclj--take-value stack value-p))
-             (opening-token (parseclj--take-token (nthcdr (length top-value) stack) value-p '(:discard :tag)))
-             (new-stack (nthcdr (+ (length top-value) (length opening-token)) stack)))
-        (when (and top-value opening-token)
+      (let (top-value
+            opening-token
+            new-stack)
+        (setq top-value (parseclj--take-value stack value-p))
+        (setq opening-token (parseclj--take-token (nthcdr (length top-value) stack) value-p '(:discard :tag)))
+        (while (and top-value opening-token)
           ;; (message "Reducing...")
           ;; (message "  - STACK %S" stack)
-          ;; (message "  - OPENING_TOKEN %S" opening-token)
-          ;; (message "  - TOP_VALUE %S\n" top-value)
-          (setq stack (funcall reduce-branch new-stack (car opening-token) (append (cdr opening-token) top-value) options))))
+          ;; (message "  - OPENING-TOKEN %S" opening-token)
+          ;; (message "  - TOP-VALUE %S" top-value)
+          (setq new-stack (nthcdr (+ (length top-value) (length opening-token)) stack))
+          (setq stack (funcall reduce-branch new-stack (car opening-token) (append (cdr opening-token) top-value) options))
+
+          (setq top-value (parseclj--take-value stack value-p))
+          (setq opening-token (parseclj--take-token (nthcdr (length top-value) stack) value-p '(:discard :tag)))))
 
       (setq token (parseclj-lex-next)))
 

--- a/parseclj-parser.el
+++ b/parseclj-parser.el
@@ -203,11 +203,9 @@ functions. Additionally the following options are recognized
        (t (push token stack)))
 
       ;; Reduce based on top two items on the stack (special prefixed elements)
-      (let (top-value
-            opening-token
-            new-stack)
-        (setq top-value (parseclj--take-value stack value-p))
-        (setq opening-token (parseclj--take-token (nthcdr (length top-value) stack) value-p '(:discard :tag)))
+      (let* ((top-value (parseclj--take-value stack value-p))
+             (opening-token (parseclj--take-token (nthcdr (length top-value) stack) value-p '(:discard :tag)))
+             new-stack)
         (while (and top-value opening-token)
           ;; (message "Reducing...")
           ;; (message "  - STACK %S" stack)

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -114,6 +114,15 @@
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
 
   (with-temp-buffer
+    (insert "\\u \\v \\w")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u" 1)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :whitespace " " 3)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\v" 4)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :whitespace " " 6)))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\w" 7))))
+
+  (with-temp-buffer
     (insert "\\u0078\\o170")
     (goto-char 1)
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u0078" 1)))

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -114,17 +114,6 @@
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
 
   (with-temp-buffer
-    (insert "\\newline\\return\\space\\tab\\a\\b\\c")
-    (goto-char 1)
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\newline" 1)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\return" 9)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\space" 16)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\tab" 22)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\a" 26)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\b" 28)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\c" 30))))
-
-  (with-temp-buffer
     (insert "\\u0078\\o170")
     (goto-char 1)
     (should (equal (parseclj-lex-next) (parseclj-lex-token :character "\\u0078" 1)))

--- a/test/parseclj-test-data.el
+++ b/test/parseclj-test-data.el
@@ -275,7 +275,7 @@
                                              (:value . 12)))))))))
 
 
-       "tag"
+       "tag-1"
        (a-list
         :source "#foo/bar [1]"
         :ast '((:node-type . :root)
@@ -290,7 +290,7 @@
                                                             (:form . "1")
                                                             (:value . 1))))))))))))
 
-       "nested-tag"
+       "tag-2"
        (a-list
         :source "(fn #param :param-name 1)"
         :ast '((:node-type . :root)
@@ -312,6 +312,30 @@
                                              (:position . 24)
                                              (:form . "1")
                                              (:value . 1)))))))))
+
+       "nested-tags"
+       (a-list
+        :source "[#lazy-error #error {:cause \"Divide by zero\"}]"
+        :ast '((:node-type . :root)
+               (:position . 1)
+               (:children ((:node-type . :vector)
+                           (:position . 1)
+                           (:children ((:node-type . :tag)
+                                       (:position . 2)
+                                       (:tag . lazy-error)
+                                       (:children ((:node-type . :tag)
+                                                   (:position . 14)
+                                                   (:tag . error)
+                                                   (:children ((:node-type . :map)
+                                                               (:position . 21)
+                                                               (:children ((:node-type . :keyword)
+                                                                           (:position . 22)
+                                                                           (:form . ":cause")
+                                                                           (:value . :cause))
+                                                                          ((:node-type . :string)
+                                                                           (:position . 29)
+                                                                           (:form . "\"Divide by zero\"")
+                                                                           (:value . "Divide by zero")))))))))))))
 
        "booleans"
        (a-list


### PR DESCRIPTION
Previously the parser would throw on nested tags, complaining for a mismatched `:tag`.  This commit fixes this behavior by looping through top values and opening tokens.

I branched off of `parseclj-lex-character-fix` because for some reason it got lost in the previous PR merging, so its changes are not in master yet.