### PR TITLE
Add support for having single quotes in symbols/keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: generic
 dist: trusty
+group: deprecated-2017Q4
 env:
   - EMACS=emacs25
   - EMACS=emacs-snapshot

--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -218,7 +218,7 @@ A token is an association list with :token-type as its first key."
   "Return t if CHAR is a valid start for a symbol.
 
 Symbols begin with a non-numeric character and can contain alphanumeric
-characters and . * + ! - _ ? $ % & = < >.  If - + or . are the first
+characters and . * + ! - _ ? $ % & = < > '.  If - + or . are the first
 character, the second character (if any) must be non-numeric.
 
 In some cases, like in tagged elements, symbols are required to start with
@@ -226,7 +226,7 @@ alphabetic characters only.  ALPHA-ONLY ensures this behavior."
   (not (not (and char
                  (or (and (<= ?a char) (<= char ?z))
                      (and (<= ?A char) (<= char ?Z))
-                     (and (not alpha-only) (member char '(?. ?* ?+ ?! ?- ?_ ?? ?$ ?% ?& ?= ?< ?> ?/))))))))
+                     (and (not alpha-only) (member char '(?. ?* ?+ ?! ?- ?_ ?? ?$ ?% ?& ?= ?< ?> ?/ ?'))))))))
 
 (defun parseclj-lex-symbol-rest-p (char)
   "Return t if CHAR is a valid character in a symbol.

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -93,6 +93,11 @@
     (should (equal (parseclj-lex-next) '((:token-type . :symbol) (:form . "foo#") (:pos . 1)))))
 
   (with-temp-buffer
+    (insert "foo'")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) '((:token-type . :symbol) (:form . "foo'") (:pos . 1)))))
+
+  (with-temp-buffer
     (insert "#inst")
     (goto-char 1)
     (should (equal (parseclj-lex-next) '((:token-type . :tag) (:form . "#inst") (:pos . 1)))))
@@ -137,6 +142,11 @@
     (insert ":hello-world")
     (goto-char 1)
     (should (equal (parseclj-lex-next) (parseclj-lex-token :keyword ":hello-world" 1))))
+
+  (with-temp-buffer
+    (insert ":hello-world'")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :keyword ":hello-world'" 1))))
 
   (with-temp-buffer
     (insert ":hello/world")


### PR DESCRIPTION
Lexer failed to recognize quotes as part of symbols (and therefore keywords as well.)

Related to: https://github.com/Unrepl/spiral/issues/8