### PR TITLE
Return `:lex-error` token when there's invalid input in `parseclj-lex-next`

### DIFF
--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -61,8 +61,6 @@ Other ATTRIBUTES can be given as a flat list of key-value pairs."
   "Create a lexer error token starting at POS.
 ERROR-TYPE is an optional keyword to attach to the created token,
 as the means for providing more information on the error."
-  (when (= pos (point))
-    (right-char))
   (apply #'parseclj-lex-token
          :lex-error
          (buffer-substring-no-properties pos (point))
@@ -420,7 +418,9 @@ See `parseclj-lex-token'."
             (parseclj-lex-error-token pos :invalid-hashtag-dispatcher)))))
 
        (t
-        (parseclj-lex-error-token pos))))))
+        (progn
+          (right-char)
+          (parseclj-lex-error-token pos)))))))
 
 (provide 'parseclj-lex)
 

--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -420,7 +420,7 @@ See `parseclj-lex-token'."
             (parseclj-lex-error-token pos :invalid-hashtag-dispatcher)))))
 
        (t
-        (concat ":(" (char-to-string char)))))))
+        (parseclj-lex-error-token pos))))))
 
 (provide 'parseclj-lex)
 

--- a/parseclj-lex.el
+++ b/parseclj-lex.el
@@ -57,6 +57,19 @@ Tokens at a mimimum have these attributes
 Other ATTRIBUTES can be given as a flat list of key-value pairs."
   (apply 'a-list :token-type type :form form :pos pos attributes))
 
+(defun parseclj-lex-error-token (pos &optional error-type)
+  "Create a lexer error token starting at POS.
+ERROR-TYPE is an optional keyword to attach to the created token,
+as the means for providing more information on the error."
+  (when (= pos (point))
+    (right-char))
+  (apply #'parseclj-lex-token
+         :lex-error
+         (buffer-substring-no-properties pos (point))
+         pos
+         (when error-type
+           (list :error-type error-type))))
+
 (defun parseclj-lex-token-p (token)
   "Is the given TOKEN a parseclj-lex TOKEN.
 
@@ -193,11 +206,7 @@ A token is an association list with :token-type as its first key."
                         (and (member char '(?. ?* ?+ ?! ?- ?_ ?? ?$ ?& ?= ?< ?> ?/)))))
           (progn
             (right-char)
-            (parseclj-lex-token :lex-error
-                                (buffer-substring-no-properties pos (point))
-                                pos
-                                :error-type :invalid-number-format))
-
+            (parseclj-lex-error-token pos :invalid-number-format))
         (parseclj-lex-token :number
                             (buffer-substring-no-properties pos (point))
                             pos)))))
@@ -270,7 +279,7 @@ token is returned."
         (progn
           (right-char)
           (parseclj-lex-token :string (buffer-substring-no-properties pos (point)) pos))
-      (parseclj-lex-token :lex-error (buffer-substring-no-properties pos (point)) pos))))
+      (parseclj-lex-error-token pos :invalid-string))))
 
 (defun parseclj-lex-lookahead (n)
   "Return a lookahead string of N characters after point."
@@ -322,7 +331,7 @@ See `parseclj-lex-symbol', `parseclj-lex-symbol-start-p'."
     (if (equal (char-after (point)) ?:) ;; three colons in a row => lex-error
         (progn
           (right-char)
-          (parseclj-lex-token :lex-error (buffer-substring-no-properties pos (point)) pos :error-type :invalid-keyword))
+          (parseclj-lex-error-token pos :invalid-keyword))
       (progn
         (while (or (parseclj-lex-symbol-rest-p (char-after (point)))
                    (equal (char-after (point)) ?#))
@@ -408,7 +417,7 @@ See `parseclj-lex-token'."
             (while (not (or (parseclj-lex-at-whitespace-p)
                             (parseclj-lex-at-eof-p)))
               (right-char))
-            (parseclj-lex-token :lex-error (buffer-substring-no-properties pos (point)) pos :error-type :invalid-hashtag-dispatcher)))))
+            (parseclj-lex-error-token pos :invalid-hashtag-dispatcher)))))
 
        (t
         (concat ":(" (char-to-string char)))))))

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -283,7 +283,7 @@
   (with-temp-buffer
     (insert "\"abc")
     (goto-char 1)
-    (should (equal (parseclj-lex-string) (parseclj-lex-token :lex-error "\"abc" 1))))
+    (should (equal (parseclj-lex-string) (parseclj-lex-token :lex-error "\"abc" 1 :error-type :invalid-string))))
 
   (with-temp-buffer
     (insert "\"abc\\\"\"")"abc\""

--- a/test/parseclj-lex-test.el
+++ b/test/parseclj-lex-test.el
@@ -203,7 +203,12 @@
     (should (equal (parseclj-lex-next) (parseclj-lex-token :number "13" 18)))
     (should (equal (parseclj-lex-next) (parseclj-lex-token :whitespace " " 20)))
     (should (equal (parseclj-lex-next) (parseclj-lex-token :number "14" 21)))
-    (should (equal (parseclj-lex-next) (parseclj-lex-token :rparen ")" 23)))))
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :rparen ")" 23))))
+
+  (with-temp-buffer
+    (insert "~")
+    (goto-char 1)
+    (should (equal (parseclj-lex-next) (parseclj-lex-token :lex-error "~" 1)))))
 
 (ert-deftest parseclj-lex-test-at-number-p ()
   (dolist (str '("123" ".9" "+1" "0" "-456"))


### PR DESCRIPTION
I added a new `parseclj-lex-error-token` helper function and applied it everywhere there was a `:lex-error`.